### PR TITLE
Bump klaus base image from 0.0.32 to 0.0.37

### DIFF
--- a/klaus-go/Dockerfile
+++ b/klaus-go/Dockerfile
@@ -1,7 +1,7 @@
 # OCI metadata is set via --annotation at build time.
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}-alpine AS go-source
-FROM gsoci.azurecr.io/giantswarm/klaus:0.0.32
+FROM gsoci.azurecr.io/giantswarm/klaus:0.0.37
 USER root
 RUN apk add --no-cache git
 COPY --from=go-source /usr/local/go /usr/local/go

--- a/klaus-go/Dockerfile.debian
+++ b/klaus-go/Dockerfile.debian
@@ -1,7 +1,7 @@
 # OCI metadata is set via --annotation at build time.
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION} AS go-source
-FROM gsoci.azurecr.io/giantswarm/klaus-debian:0.0.32
+FROM gsoci.azurecr.io/giantswarm/klaus-debian:0.0.37
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Update alpine-based `klaus` base image from 0.0.32 to 0.0.37 in `klaus-go/Dockerfile`
- Update debian-based `klaus-debian` base image from 0.0.32 to 0.0.37 in `klaus-go/Dockerfile.debian`

## Test plan
- [ ] Verify CI builds pass for both alpine and debian variants
- [ ] Confirm Go toolchain still works correctly on the updated base images

🤖 Generated with [Claude Code](https://claude.com/claude-code)