### PR TITLE
feat: automerge klaus image updates and receive release dispatch

### DIFF
--- a/.github/workflows/klaus-release-dispatch.yaml
+++ b/.github/workflows/klaus-release-dispatch.yaml
@@ -1,0 +1,74 @@
+---
+# yamllint disable rule:truthy
+name: Klaus Release Dispatch
+on:
+  repository_dispatch:
+    types: [klaus-release]
+
+permissions: {}
+
+jobs:
+  bump_version:
+    name: Bump Klaus Base Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Validate version
+        id: validate
+        env:
+          RAW_VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RAW_VERSION" ]; then
+            echo "::error::Missing version in client_payload"
+            exit 1
+          fi
+          # Strip leading "v" if present, then enforce strict semver
+          VERSION="${RAW_VERSION#v}"
+          if ! echo "$VERSION" | grep -qxE '[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Invalid version format: $RAW_VERSION"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Update Dockerfiles
+        env:
+          NEW_VERSION: ${{ steps.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Updating klaus base images to ${NEW_VERSION}"
+          while IFS= read -r df; do
+            sed -i -E \
+              "s|(FROM gsoci\.azurecr\.io/giantswarm/klaus(-[a-z]+)?):[0-9]+\.[0-9]+\.[0-9]+|\1:${NEW_VERSION}|g" \
+              "$df"
+          done < <(find . -name 'Dockerfile*' -path '*/klaus-*/*')
+          git diff
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Dockerfiles changed, skipping PR"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.check.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump klaus base image to ${{ steps.validate.outputs.version }}"
+          title: "chore: bump klaus base image to ${{ steps.validate.outputs.version }}"
+          body: |
+            Automated PR triggered by `repository_dispatch` from the upstream klaus release.
+
+            Updates all `FROM` lines referencing `gsoci.azurecr.io/giantswarm/klaus*` to version `${{ steps.validate.outputs.version }}`.
+          branch: bump-klaus-dispatch-${{ steps.validate.outputs.version }}
+          delete-branch: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,7 @@
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["giantswarm\\/klaus"],
       "groupName": "klaus-images",
+      "automerge": true,
     },
   ],
 }


### PR DESCRIPTION
## Summary

- Enable Renovate automerge for the `klaus-images` package group so base image bumps merge automatically once CI passes
- Add a `repository_dispatch` workflow (`klaus-release`) that validates the incoming version, updates all `FROM` lines in `klaus-*/Dockerfile*`, and opens a PR for near-instant propagation of upstream releases
- Include strict semver validation, error handling (`set -euo pipefail`), no-op detection, and version-specific branch names to prevent race conditions

Closes #1

## How it was tested

- Reviewed `renovate.json5` change: single-line `automerge: true` addition to the existing `klaus-images` rule
- Verified the `sed` regex matches both `gsoci.azurecr.io/giantswarm/klaus:X.Y.Z` and `gsoci.azurecr.io/giantswarm/klaus-debian:X.Y.Z` patterns in the existing Dockerfiles
- Confirmed the version validation step rejects non-semver input and strips `v` prefix
- Workflow skips PR creation when no Dockerfiles are actually changed

## Self-review

**code-reviewer**: Addressed all critical findings — added `set -euo pipefail`, switched from `find | while` pipe to process substitution to propagate errors, version-specific branch names, and no-op detection with `::notice::`.

**security-auditor**: Addressed critical (C1) and high (H1) findings — added strict semver regex validation before the version reaches `sed` or PR fields, and all downstream references use the validated step output rather than raw `client_payload`. Permissions scoped to job level with workflow-level `permissions: {}`. Noted findings (M2: pinning Actions to SHA, M3: sender verification) are acknowledged but deferred to match existing repo conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)