### PR TITLE
feat: notify personality repos on toolchain release via repository_dispatch

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -30,6 +30,7 @@ jobs:
           git config user.email "${GIT_ACTOR}@users.noreply.github.com"
 
       - name: Detect changed images and create releases
+        id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -38,9 +39,11 @@ jobs:
 
           if [ -z "$CHANGED" ]; then
             echo "No image directories changed, skipping release"
+            echo "released=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          RELEASED=()
           for dir in $CHANGED; do
             NAME="${dir#klaus-}"
             LATEST=$(git tag -l "${NAME}/v*" --sort=-v:refname | head -1)
@@ -59,4 +62,52 @@ jobs:
             sleep 2
 
             gh release create "$NEXT" --title "$NEXT" --generate-notes
+            RELEASED+=("${NAME}=${NEXT#${NAME}/v}")
           done
+
+          # Pass released toolchains as "name=version" pairs (space-separated)
+          echo "released=${RELEASED[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify downstream repos
+        if: steps.release.outputs.released != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+          RELEASED: ${{ steps.release.outputs.released }}
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::DOWNSTREAM_DISPATCH_TOKEN not set" \
+              "- skipping downstream notification"
+            exit 0
+          fi
+
+          DOWNSTREAM_REPOS=(
+            "giantswarm/klaus-personalities"
+          )
+          FAILED=0
+          for entry in $RELEASED; do
+            TOOLCHAIN="${entry%%=*}"
+            VERSION="${entry#*=}"
+
+            if ! echo "$VERSION" | grep -qxE '[0-9]+\.[0-9]+\.[0-9]+'; then
+              echo "::warning::Skipping invalid version: $VERSION"
+              continue
+            fi
+
+            for repo in "${DOWNSTREAM_REPOS[@]}"; do
+              echo "Dispatching to $repo (toolchain=$TOOLCHAIN, version=$VERSION)"
+              if gh api \
+                --method POST \
+                "/repos/${repo}/dispatches" \
+                -f "event_type=toolchain-release" \
+                -f "client_payload[toolchain]=${TOOLCHAIN}" \
+                -f "client_payload[version]=${VERSION}"; then
+                echo "  -> Notified $repo"
+              else
+                echo "::warning::Failed to notify $repo" >&2
+                FAILED=1
+              fi
+            done
+          done
+          exit $FAILED


### PR DESCRIPTION
## Summary

- Adds a "Notify downstream repos" step to the auto-release workflow that sends `repository_dispatch` events (`event_type: toolchain-release`) with the toolchain name and version in `client_payload` to `giantswarm/klaus-personalities` after a successful release
- Uses a dedicated `DOWNSTREAM_DISPATCH_TOKEN` secret for cross-repo API access
- Notification failures surface as GitHub Actions warnings but do not block the release (`continue-on-error: true`)
- Version is validated with semver regex before dispatching

Closes #4

## Setup required

A `DOWNSTREAM_DISPATCH_TOKEN` repository secret must be configured with a fine-grained PAT that has `contents:write` permission on `giantswarm/klaus-personalities`. If the secret is not set, the step logs a warning and exits cleanly.

## How it was tested

- Validated YAML syntax
- Reviewed against GitHub Actions expression injection best practices (all dynamic values passed via `env:` blocks, not inline `${{ }}` interpolation in shell)
- Follows the same dispatch pattern established in giantswarm/klaus PR #92

## Self-review

**Code review (base:code-reviewer):**
- Confirmed `env:` block pattern is used correctly for passing step outputs (no shell injection risk)
- Version validation with `grep -qxE` is properly anchored
- `DOWNSTREAM_DISPATCH_TOKEN` guard handles missing secret gracefully
- `continue-on-error: true` correctly prevents dispatch failures from blocking releases

**Security audit (code-quality:security-auditor):**
- No `${{ }}` expressions inside `run:` blocks (correct pattern throughout)
- Defense-in-depth: version validated on both sender and receiver sides
- Added `set -euo pipefail` to dispatch step per auditor recommendation
- Token scope is a deployment concern: recommend using a fine-grained PAT scoped to `giantswarm/klaus-personalities` only

## Test plan

- [ ] Configure `DOWNSTREAM_DISPATCH_TOKEN` secret with appropriate permissions
- [ ] Merge a change to a `klaus-*` directory to trigger the auto-release workflow
- [ ] Verify the dispatch step runs and sends the correct payload
- [ ] Verify `giantswarm/klaus-personalities` receives the `toolchain-release` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)