### PR TITLE
feat: enable automerge on dispatch-created PRs

### DIFF
--- a/.github/workflows/klaus-release-dispatch.yaml
+++ b/.github/workflows/klaus-release-dispatch.yaml
@@ -78,4 +78,5 @@ jobs:
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER"


### PR DESCRIPTION
## Summary

- Adds `id: cpr` to the `create-pull-request` step so its outputs are referenceable
- Adds an "Enable automerge" step that runs `gh pr merge --auto --squash` on the newly created PR
- PR number is passed via `env:` variable (not inline `${{ }}`) to avoid expression injection

Dispatch-created PRs will now merge automatically once CI passes, removing manual intervention.

Closes #8

## Self-review

**Code review (base:code-reviewer):** No critical findings. Notes: the truthy check on `pull-request-number` is appropriate since `create-pull-request` emits an empty string when no PR is created. Squash merge strategy is consistent with the `auto-release.yaml` workflow's `HEAD~1` diff logic.

**Security audit (code-quality:security-auditor):** No critical findings. One low-severity defense-in-depth recommendation was applied: PR number is now passed through an `env:` binding instead of inline interpolation in the `run:` block. Token permissions (`contents: write`, `pull-requests: write`) are sufficient and follow least privilege.

## Test plan

- [ ] Trigger a `repository_dispatch` with `event_type: klaus-release` and a valid version payload
- [ ] Verify the created PR has automerge enabled (`autoMergeRequest` is non-null)
- [ ] Verify the PR merges automatically once CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)