### PR TITLE
chore: bump klaus base image from 0.0.38 to 0.0.40

### DIFF
--- a/klaus-go/Dockerfile
+++ b/klaus-go/Dockerfile
@@ -1,7 +1,7 @@
 # OCI metadata is set via --annotation at build time.
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}-alpine AS go-source
-FROM gsoci.azurecr.io/giantswarm/klaus:0.0.38
+FROM gsoci.azurecr.io/giantswarm/klaus:0.0.40
 USER root
 RUN apk add --no-cache git
 COPY --from=go-source /usr/local/go /usr/local/go

--- a/klaus-go/Dockerfile.debian
+++ b/klaus-go/Dockerfile.debian
@@ -1,7 +1,7 @@
 # OCI metadata is set via --annotation at build time.
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION} AS go-source
-FROM gsoci.azurecr.io/giantswarm/klaus-debian:0.0.38
+FROM gsoci.azurecr.io/giantswarm/klaus-debian:0.0.40
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Bumps `klaus` base image from `0.0.38` to `0.0.40` in both Alpine and Debian Dockerfiles
- Replaces the closed PR #7 which had stale CI failures due to a race condition (base images weren't available in the registry when CI ran)
- The v0.0.40 images are now published and available

Closes #9

## Changes

- `klaus-go/Dockerfile`: `gsoci.azurecr.io/giantswarm/klaus:0.0.38` → `0.0.40`
- `klaus-go/Dockerfile.debian`: `gsoci.azurecr.io/giantswarm/klaus-debian:0.0.38` → `0.0.40`

## Related cleanup

- Closed PR #7 in this repo (stale CI failures)
- Closed PR #42 in `klaus-toolchains-internal` (same race condition; needs fresh bump in that repo)
- Closed PR #38 in `klaus-toolchains-internal` (stale Renovate PR bumping to 0.0.39, superseded by 0.0.40)

## Internal repo follow-up

`klaus-toolchains-internal` still needs a fresh PR to bump its Dockerfiles to v0.0.40. Either:
1. Re-trigger the `repository_dispatch` from the klaus release workflow, or
2. Manually create a bump PR in that repo

## Self-review

**Code review (base:code-reviewer):** No critical issues. The change is a minimal, consistent version bump across both Dockerfile variants. Pre-existing notes: `GO_VERSION=1.25` and `actions/checkout@v6` are out of scope for this PR.

**Security audit (code-quality:security-auditor):** No new vulnerabilities introduced. Existing recommendation to adopt digest-pinned base images is noted but pre-existing.

## Test plan

- [ ] CI builds both `klaus-go` Alpine and Debian images successfully with the new base
- [ ] Auto-release workflow creates versioned tags after merge
- [ ] Downstream personality repos receive the release dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)