### PR TITLE
chore: bump klaus base images to 0.0.96

### DIFF
--- a/klaus-go/Dockerfile
+++ b/klaus-go/Dockerfile
@@ -1,7 +1,7 @@
 # OCI metadata is set via --annotation at build time.
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}-alpine AS go-source
-FROM gsoci.azurecr.io/giantswarm/klaus:0.0.94
+FROM gsoci.azurecr.io/giantswarm/klaus:0.0.96
 USER root
 RUN apk add --no-cache git
 COPY --from=go-source /usr/local/go /usr/local/go

--- a/klaus-go/Dockerfile.debian
+++ b/klaus-go/Dockerfile.debian
@@ -1,7 +1,7 @@
 # OCI metadata is set via --annotation at build time.
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION} AS go-source
-FROM gsoci.azurecr.io/giantswarm/klaus-debian:0.0.94
+FROM gsoci.azurecr.io/giantswarm/klaus-debian:0.0.96
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Bump klaus base images from 0.0.94 to 0.0.96.

Key changes in klaus 0.0.96:
- Persistent subprocess crash reporting (giantswarm/klaus#184)

Made with [Cursor](https://cursor.com)