### PR TITLE
ci: migrate to push-to-registries on architect-orb 8.2.2 (enables Sigstore signing)

### DIFF
--- a/.circleci/generate-config.sh
+++ b/.circleci/generate-config.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Tag builds:    single job for the image matching the tag prefix (multi-arch).
 # No changes:    minimal no-op config.
 
-ARCHITECT_ORB="giantswarm/architect@6.14.0"
+ARCHITECT_ORB="giantswarm/architect@8.2.2"
 
 # Keep in sync with Makefile ANNOTATION_* variables.
 ANNOTATION_AUTHOR_NAME="Giant Swarm GmbH"
@@ -50,8 +50,9 @@ get_annotations() {
 emit_branch_job() {
   local name="$1" dockerfile="$2" dir="$3"
   cat <<EOF
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-${name}
         image: giantswarm/klaus-toolchains/${name}
         dockerfile: ./${dir}/${dockerfile}
@@ -65,9 +66,12 @@ EOF
 
 emit_tag_job() {
   local name="$1" dockerfile="$2" dir="$3" prefix="$4"
+  # split-china-push skips Aliyun on the buildx push; the companion
+  # sync-china-registry job mirrors gsoci -> Aliyun via galaxy-runner.
   cat <<EOF
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-${name}
         image: giantswarm/klaus-toolchains/${name}
         dockerfile: ./${dir}/${dockerfile}
@@ -75,8 +79,21 @@ emit_tag_job() {
         platforms: "linux/amd64,linux/arm64"
         resource_class: medium
         git-tag-prefix: "${prefix}"
+        split-china-push: true
         annotations: |
 $(get_annotations "$name" "          ")
+        filters:
+          tags:
+            only: /^${prefix}\\/v.*/
+          branches:
+            ignore: /.*/
+
+    - architect/sync-china-registry:
+        context: architect
+        name: sync-china-registry-${name}
+        image: giantswarm/klaus-toolchains/${name}
+        requires:
+        - push-${name}
         filters:
           tags:
             only: /^${prefix}\\/v.*/


### PR DESCRIPTION
Resolves #38 and brings the toolchain image build under the same supply-chain story as the rest of the lab multi-arch consumers.

**Changes in `.circleci/generate-config.sh`:**
- `ARCHITECT_ORB` bumped from `giantswarm/architect@6.14.0` to `giantswarm/architect@8.2.2`.
- Both `emit_branch_job` and `emit_tag_job` switched from the deprecated `architect/push-to-registries-multiarch` to `architect/push-to-registries` with `multiarch: true`. Same interface (image, dockerfile, build-context, platforms, resource_class, git-tag-prefix, annotations).
- Tag jobs now use `split-china-push: true` and emit a companion `architect/sync-china-registry` job, mirroring the pattern in `giantswarm/klaus` / `giantswarm/muster` / etc. Aliyun mirror failures no longer block the toolchain image publish.

**What this unlocks on the next tag push:**
- Cosign keyless signature on each toolchain image's manifest index (OCI 1.1 referrer).
- SLSA `provenance: min` and SPDX `sbom: true` inline attestations on the image index.
- `cosign verify` step asserting the CircleCI OIDC issuer and `github.com/giantswarm/klaus-toolchains` SAN identity.
- `hadolint` warn-level Dockerfile linting before the buildx build.

Closes #38
Tracked under: giantswarm/giantswarm#36627

Made with [Cursor](https://cursor.com)