### PR TITLE
feat: install gnupg for GPG-signed agent commits

### DIFF
--- a/klaus-go/Dockerfile
+++ b/klaus-go/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}-alpine AS go-source
 FROM gsoci.azurecr.io/giantswarm/klaus:0.0.177
 USER root
-RUN apk add --no-cache git
+RUN apk add --no-cache git gnupg
 COPY --from=go-source /usr/local/go /usr/local/go
 RUN mkdir -p /go && chown klaus:klaus /go
 USER klaus

--- a/klaus-go/Dockerfile.debian
+++ b/klaus-go/Dockerfile.debian
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.26
 FROM golang:${GO_VERSION} AS go-source
 FROM gsoci.azurecr.io/giantswarm/klaus-debian:0.0.177
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends git \
+RUN apt-get update && apt-get install -y --no-install-recommends git gnupg \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=go-source /usr/local/go /usr/local/go
 RUN mkdir -p /go && chown klaus:klaus /go


### PR DESCRIPTION
## Summary

- Add `gnupg` to the klaus-go toolchain (alpine + debian) so agents can produce GPG-signed commits via klausctl's forwarded gpg-agent socket (giantswarm/klausctl#270).

Closes #58

## Test plan

- [ ] CI image build passes; `gpg --version` works in the built image.

Made with [Cursor](https://cursor.com)